### PR TITLE
Regexp-quote strings of avy-goto-char* functions.

### DIFF
--- a/avy-jump.el
+++ b/avy-jump.el
@@ -277,6 +277,7 @@ When ARG is non-nil, flip the window scope."
               (not avy-all-windows)
             avy-all-windows))
          (avy-keys (number-sequence ?a ?z))
+	 (case-fold-search nil)
          (candidates (avy--regex-candidates
                       "\\(\\b\\sw\\)\\|\\(?:[^A-Z]\\([A-Z]\\)\\)")))
     (dolist (x candidates)

--- a/avy-jump.el
+++ b/avy-jump.el
@@ -236,7 +236,7 @@ The window scope is determined by `avy-all-windows'.
 When ARG is non-nil, flip the window scope."
   (interactive "P")
   (avy--generic-jump
-   (string (read-char "char: ")) arg))
+   (regexp-quote (string (read-char "char: "))) arg))
 
 ;;;###autoload
 (defun avy-goto-char-2 (&optional arg)
@@ -244,9 +244,9 @@ When ARG is non-nil, flip the window scope."
 When ARG is non-nil, flip the window scope."
   (interactive "P")
   (avy--generic-jump
-   (string
-    (read-char "char 1: ")
-    (read-char "char 2: "))
+   (regexp-quote (string
+		  (read-char "char 1: ")
+		  (read-char "char 2: ")))
    arg))
 
 ;;;###autoload


### PR DESCRIPTION
Before this commit, avy-goto-char with char ^ would inf-loop because the
resulting string "^" is treated as a regular expressions.  However, with
the avy-goto-char* function, the char should be treated literally.  For
example, in Clojure ^:foo is treated as metadata annotation and thus ^
is a likely jump target.